### PR TITLE
Removes restriction of 4 unit slots

### DIFF
--- a/BiggerDrops/BiggerDrops/Patch.cs
+++ b/BiggerDrops/BiggerDrops/Patch.cs
@@ -210,10 +210,7 @@ namespace BiggerDrops {
                 }
                 else
                 {
-                    if (contract.Override.maxNumberOfPlayerUnits < 4)
-                    {
-                        maxUnits = contract.Override.maxNumberOfPlayerUnits;
-                    }
+                  maxUnits = contract.Override.maxNumberOfPlayerUnits;
                 }
             }
          } else {


### PR DESCRIPTION
Mission Control fixes the `maxNumberOfPlayerUnits` issue for values above 4 in the contract override.

This restriction can now be removed (if I understood correctly) to enable this functionality correctly.

Testing seemed to show it working as intended with this change but please review and confirm.

MC 1.0.4 has no release date yet so we might want to keep this PR out until it's ready.