### PR TITLE
Small Bugfix

### DIFF
--- a/BiggerDrops/BiggerDrops/HolderClasses.cs
+++ b/BiggerDrops/BiggerDrops/HolderClasses.cs
@@ -34,7 +34,6 @@ namespace BiggerDrops {
     public bool limitFlashpointDrop {get; set;}
     public bool count4AsUnlimited {get; set;}
 
-
   public int additinalMechSlots {
       get {
         if (allowUpgrades && companyStats != null)
@@ -138,8 +137,7 @@ namespace BiggerDrops {
     public void UpdateCULances() {
       if (CustomUnitsAPI.Detected()) {
         int lanceCount = 1;
-        int mCount = BiggerDrops.
-                    .additinalMechSlots;
+        int mCount = BiggerDrops.settings.additinalMechSlots;
         while (mCount > 0)
         {
             lanceCount++;

--- a/BiggerDrops/BiggerDrops/HolderClasses.cs
+++ b/BiggerDrops/BiggerDrops/HolderClasses.cs
@@ -32,9 +32,10 @@ namespace BiggerDrops {
     public int CuInitialVehicles { get; set; }
     public bool respectFourDropLimit {get; set;}
     public bool limitFlashpointDrop {get; set;}
+    public bool count4AsUnlimited {get; set;}
 
 
-    public int additinalMechSlots {
+  public int additinalMechSlots {
       get {
         if (allowUpgrades && companyStats != null)
         {
@@ -131,12 +132,14 @@ namespace BiggerDrops {
       CuInitialVehicles = 0;
       limitFlashpointDrop = true;
       respectFourDropLimit = false;
+      count4AsUnlimited = true;
     }
     
     public void UpdateCULances() {
       if (CustomUnitsAPI.Detected()) {
         int lanceCount = 1;
-        int mCount = BiggerDrops.settings.additinalMechSlots;
+        int mCount = BiggerDrops.
+                    .additinalMechSlots;
         while (mCount > 0)
         {
             lanceCount++;

--- a/BiggerDrops/BiggerDrops/Patch.cs
+++ b/BiggerDrops/BiggerDrops/Patch.cs
@@ -201,18 +201,24 @@ namespace BiggerDrops {
                         maxUnits = Math.Min(4, contract.Override.maxNumberOfPlayerUnits);
                     }
                 }
-                if (BiggerDrops.settings.respectFourDropLimit)
+                if (BiggerDrops.settings.count4AsUnlimited)
+                {
+                    if (BiggerDrops.settings.respectFourDropLimit)
+                    {
+                        if ((contract.Override.maxNumberOfPlayerUnits != -1) || (contract.Override.maxNumberOfPlayerUnits != 4))
+                        {
+                            maxUnits = contract.Override.maxNumberOfPlayerUnits;
+                        }
+                    }
+                else
                 {
                     if (contract.Override.maxNumberOfPlayerUnits != -1)
                     {
                         maxUnits = contract.Override.maxNumberOfPlayerUnits;
                     }
                 }
-                else
-                {
-                  maxUnits = contract.Override.maxNumberOfPlayerUnits;
                 }
-            }
+                    }
          } else {
           maxUnits = Settings.MAX_ADDITINAL_MECH_SLOTS + Settings.MAX_ADDITINAL_MECH_SLOTS;
           BiggerDrops.baysAlreadyAdded = 0;


### PR DESCRIPTION
Yesterday's update was causing (in Battletech Extended CE) all contracts except the ones added by Mission Control to force a maximum of 4 'Mechs per deployment. I've coded a small fix for that, with a new setting of 'count4AsUnlimited', default true, after discussion with CWolf and inspiration from the RogueTech team.