### PR TITLE
Remove tonnage restriction for flashpoints.

### DIFF
--- a/BiggerDrops/BiggerDrops/Patch.cs
+++ b/BiggerDrops/BiggerDrops/Patch.cs
@@ -235,7 +235,7 @@ namespace BiggerDrops {
           //__instance.lanceMaxTonnage = BiggerDrops.settings.defaultMaxTonnage;
           return;
         } else
-        if (contract.Override.lanceMaxTonnage == -1) {
+        if (contract.Override.lanceMaxTonnage == -1 && !contract.IsFlashpointCampaignContract && !contract.IsFlashpointContract) {
           __instance.lanceMaxTonnage = BiggerDrops.settings.defaultMaxTonnage;
         }
       } catch (Exception e) {


### PR DESCRIPTION
Problem with flashpoint missions together with lowered drop limits: 

After mission 1 you have the option to select a heavy lance or a light lance
I selected the heavy lance, and am unable to start mission 2 because it has a drop limit of 205 tons while the preset lance (which you can't change) has a weight of 245